### PR TITLE
catch mousedown event in close button

### DIFF
--- a/js/bootstrap-colorpicker-module.js
+++ b/js/bootstrap-colorpicker-module.js
@@ -568,7 +568,7 @@ angular.module('colorpicker.module', [])
             }
           }
 
-          colorpickerTemplate.find('button').on('click', function () {
+          colorpickerTemplate.find('button').on('mousedown click', function () {
             hideColorpickerTemplate();
           });
 


### PR DESCRIPTION
Otherwise, the stopPropagation on colorpickerTemplate.on("mousedown") prevents it from closing